### PR TITLE
fix: fix tests

### DIFF
--- a/test/test-connector-openapi3.js
+++ b/test/test-connector-openapi3.js
@@ -81,13 +81,13 @@ describe('swagger connector for OpenApi 3.0', () => {
     });
 
     it('creates models', function() {
-      (typeof Todo.TodoController_findTodos).should.eql('function');
-      (typeof Todo.todoControllerFindTodos).should.eql('function');
-      (typeof Todo.apis.TodoController.findTodos).should.eql('function');
+      (typeof Todo.TodoController_find).should.eql('function');
+      (typeof Todo.todoControllerFind).should.eql('function');
+      (typeof Todo.apis.TodoController.find).should.eql('function');
     });
 
     it('supports model methods', function(done) {
-      Todo.TodoController_findTodos({filter}, function(err, res) {
+      Todo.TodoController_find({filter}, function(err, res) {
         if (err) return done(err);
         res.status.should.eql(200);
         done();
@@ -95,21 +95,21 @@ describe('swagger connector for OpenApi 3.0', () => {
     });
 
     it('supports model methods returning a Promise', done => {
-      Todo.TodoController_findTodos({filter}).then(function onSuccess(res) {
+      Todo.TodoController_find({filter}).then(function onSuccess(res) {
         res.should.have.property('status', 200);
         done();
       }, /* on error */ done);
     });
 
     it('supports model methods by x-operation-name', done => {
-      Todo.findTodos({filter}).then(function onSuccess(res) {
+      Todo.find({filter}).then(function onSuccess(res) {
         res.should.have.property('status', 200);
         done();
       }, /* on error */ done);
     });
 
     it('exports apis by tag', done => {
-      Todo.apis.TodoController.findTodos({filter}).then(function onSuccess(res) {
+      Todo.apis.TodoController.find({filter}).then(function onSuccess(res) {
         res.should.have.property('status', 200);
         done();
       }, /* on error */ done);
@@ -131,13 +131,13 @@ describe('swagger connector for OpenApi 3.0', () => {
       };
       const ds1 = await createDataSource(specUrl, {mapToMethods: mapToMethods});
       const Todo1 = ds1.createModel('Todo', {}, {base: 'Model'});
-      should(Object.keys(Todo1)).containEql('TodoController$findTodos');
-      should(Object.keys(Todo1.apis.TodoController)).containEql('$findTodos');
+      should(Object.keys(Todo1)).containEql('TodoController$find');
+      should(Object.keys(Todo1.apis.TodoController)).containEql('$find');
     });
 
     describe('Swagger invocations', () => {
       it('invokes the createTodo', async () => {
-        const res = await Todo.TodoController_createTodo(
+        const res = await Todo.TodoController_create(
           {},
           {
             requestBody: {
@@ -153,14 +153,14 @@ describe('swagger connector for OpenApi 3.0', () => {
       it('supports positional invocation', async () => {
         const ds = await createDataSource(specUrl, {positional: true});
         const Todo = ds.createModel('Todo', {}, {base: 'Model'});
-        let res = await Todo.TodoController_createTodo({
+        let res = await Todo.TodoController_create({
           title: 'My todo 2',
         });
 
         res.status.should.eql(200);
         res.body.should.eql({id: 2, title: 'My todo 2'});
 
-        res = await Todo.TodoController_findTodoById(2, {});
+        res = await Todo.TodoController_findById(2, {});
         res.status.should.eql(200);
         res.body.should.eql({id: 2, title: 'My todo 2'});
       });
@@ -168,14 +168,14 @@ describe('swagger connector for OpenApi 3.0', () => {
       it('supports positional invocation with options', async () => {
         const ds = await createDataSource(specUrl, {positional: true});
         const Todo = ds.createModel('Todo', {}, {base: 'Model'});
-        const create = Todo.TodoController_createTodo({
+        const create = Todo.TodoController_create({
           title: 'My todo 2',
         }, {requestContentType: 'application/xml'});
         return should(create).rejectedWith(/Unprocessable Entity/);
       });
 
       it('invokes the findTodos', async () => {
-        const res = await Todo.TodoController_findTodos({filter});
+        const res = await Todo.TodoController_find({filter});
         res.status.should.eql(200);
         res.body.should.eql([
           {id: 1, title: 'My todo'},
@@ -196,7 +196,7 @@ describe('swagger connector for OpenApi 3.0', () => {
           events.push('after execute');
           next();
         });
-        await Todo.TodoController_findTodos({filter});
+        await Todo.TodoController_find({filter});
         assert.deepEqual(events, ['before execute', 'after execute']);
       });
 
@@ -214,7 +214,7 @@ describe('swagger connector for OpenApi 3.0', () => {
           return Promise.resolve();
         });
 
-        await Todo.TodoController_findTodos({filter});
+        await Todo.TodoController_find({filter});
         assert.deepEqual(events, ['before execute', 'after execute']);
       });
 
@@ -225,7 +225,7 @@ describe('swagger connector for OpenApi 3.0', () => {
         };
         const ds1 = await createDataSource(specUrl, {transformResponse: transformResponse});
         const Todo1 = ds1.createModel('Todo', {}, {base: 'Model'});
-        const res = await Todo1.apis.TodoController.findTodos({filter});
+        const res = await Todo1.apis.TodoController.find({filter});
         res.should.eql([
           {id: 1, title: 'My todo'},
           {id: 2, title: 'My todo 2'},
@@ -235,7 +235,7 @@ describe('swagger connector for OpenApi 3.0', () => {
       it('uses default transformResponse', async () => {
         const ds1 = await createDataSource(specUrl, {transformResponse: true});
         const Todo1 = ds1.createModel('Todo', {}, {base: 'Model'});
-        const res = await Todo1.apis.TodoController.findTodos({filter});
+        const res = await Todo1.apis.TodoController.find({filter});
         res.should.eql([
           {id: 1, title: 'My todo'},
           {id: 2, title: 'My todo 2'},

--- a/test/test-connector-swagger2.js
+++ b/test/test-connector-swagger2.js
@@ -68,7 +68,8 @@ describe('OpenAPI connector for Swagger 2.0', function() {
     before('connect to pet store', async () => {
       ds = await createDataSource('test/fixtures/2.0/petstore.json');
       PetService = ds.createModel('PetService', {});
-      const data = await PetService.findPetsByStatus({status: 'available'});
+      const data = await PetService.findPetsByStatus({status: 'available'},
+        {responseContentType: 'application/json'});
       should(data.body).be.Array();
       should(data.body.length).be.above(0);
       petId = data.body[data.body.length - 1].id;
@@ -109,7 +110,8 @@ describe('OpenAPI connector for Swagger 2.0', function() {
       PetService = ds.createModel('PetService', {});
 
       // https://petstore.swagger.io/v2/pet/findByStatus?status=available
-      const data = await PetService.findPetsByStatus({status: 'available'});
+      const data = await PetService.findPetsByStatus({status: 'available'},
+        {responseContentType: 'application/json'});
       should(data.body).be.Array();
       should(data.body.length).be.above(0);
       petId = data.body[data.body.length - 1].id;


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

When running `npm test`, there are failed test cases for test-connector-openapi3.js and test-connector-swagger2.js.

- test-connector-openapi3.js: updated to use the function names that exist (I believe there was a renaming on the generated function names long time ago)
- test-connector-swagger2.js: the petstore service returns xml as response, so I specified the response content type to be `application/json`. 

After the fix, here is the output from `npm test`: 

```
$ npm test

> loopback-connector-openapi@6.2.0 test
> mocha



  swagger connector with caching
    ✓ returns fresh data on the first request
    ✓ returns cached data on the second request
    ✓ includes query parameters in the cache key
    ✓ includes header parameters in the cache key
    ✓ does not cache non-GET requests
    ✓ honours TTL setting (207ms)

  OpenAPI connector - security
    Basic auth
      ✓ supports basic auth
    apiKey auth
      ✓ supports apiKey - in query
      ✓ supports apiKey - in header
    oAuth2
      ✓ supports oauth2 - in header
      ✓ supports oauth2 with token_type

  swagger connector for OpenApi 3.0
    OpenAPI spec validation against OpenAPI 3.0 specification
Connection fails: SyntaxError: [object Object] is not a valid Openapi API definition
It will be retried for the next request.
      ✓ reports error if required settings are missing
      ✓ creates `client.apis` upon datasource creation
    openapi client generation
      ✓ generates client from openapi spec url
      ✓ generates client from local openapi spec - .json file
      ✓ generates client from local openapi spec - .yaml file
      ✓ generates client from openapi spec object
    models
      ✓ creates models
      ✓ supports model methods (76ms)
      ✓ supports model methods returning a Promise
      ✓ supports model methods by x-operation-name
      ✓ exports apis by tag
      ✓ allows models to be attached before the spec is loaded
      ✓ uses custom mapToMethods
      Swagger invocations
        ✓ invokes the createTodo
        ✓ supports positional invocation (49ms)
        ✓ supports positional invocation with options
        ✓ invokes the findTodos
        ✓ invokes connector-hooks
        ✓ supports Promise-based connector-hooks
        ✓ uses custom transformResponse
        ✓ uses default transformResponse

  OpenAPI connector for Swagger 2.0
    swagger spec validation against Swagger 2.0 specification
Connection fails: SyntaxError: [object Object] is not a valid Swagger API definition
It will be retried for the next request.
      ✓ reports error if required settings are missing
      ✓ creates `client.apis` upon datasource creation (282ms)
    swagger client generation
      ✓ generates client from swagger spec url (235ms)
      ✓ generates client from local swagger spec - .json file
      ✓ generates client from local swagger spec - .yaml file
      ✓ generates client from swagger spec object
    models
      ✓ creates models
      ✓ supports model methods with callback (208ms)
      ✓ supports model methods returning a Promise (242ms)
      ✓ allows models to be attached before the spec is loaded
    Swagger invocations
      ✓ invokes the PetService (215ms)
      ✓ supports a request for xml content (215ms)
      ✓ invokes connector-hooks (217ms)
      ✓ supports Promise-based connector-hooks (234ms)

  options for openapi connector
    - supports forceOpenApi30
    ✓ supports positional & transformResponse (416ms)

  OpenAPI Spec SpecResolver
    ✓ Should set url when given spec is a url
    ✓ Should set spec object when given spec is swagger specification object
    ✓ Should not accept specification types other than string/plain object
    File handling & spec resolution
      ✓ should read & set swagger spec from a local .json file
      ✓ should read & set swagger spec from a local .yaml file
      ✓ should support .yml extension for YAML spec files
      ✓ should not accept other spec file formats than .json/.yaml
    Spec validation against Swagger schema 2.0
      ✓ should validate provided specification against swagger spec. 2.0
      ✓ should throw error if validation fails
    OpenAPI 3.0
      ✓ loads OpenAPI spec 3.0 yaml


  57 passing (5s)
  1 pending


> loopback-connector-openapi@6.2.0 posttest
> npm run lint


> loopback-connector-openapi@6.2.0 lint
> eslint .

```



<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
