### PR TITLE
fix: retrieve base url from spec url in case the servers field is empty

### DIFF
--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -129,6 +129,50 @@ OpenApiConnector.prototype.connect = function(cb) {
           responseInterceptor: self.connectorHooks.afterExecute,
         };
 
+        let baseURL, baseURLObject;
+        if (req.spec.openapi) {
+          try {
+            baseURLObject = new URL(self.settings.spec);
+            baseURL = `${baseURLObject.protocol}//${baseURLObject.host}`;
+          } catch (error) {
+            debug('Not a valid URL: %s', error);
+          }
+        }
+
+        /* servers field in the specification can possibly have the following values:
+          https://api.example.com
+          https://api.example.com:8443/v1/reports
+          http://localhost:3025/v1
+          http://10.0.81.36/v1
+          ws://api.example.com/v1
+          wss://api.example.com/v1
+          - /v1/reports
+          - /
+          - //api.example.com
+          The last three items are not absoulte paths hence the request fails,
+          */
+
+        if (baseURL) {
+          if (!req.spec.servers || !req.spec.servers.length) {
+            req.spec.servers = [{url: baseURL}];
+          } else {
+            req.spec.servers.forEach(function({url}, index) {
+              try {
+                // if it successful, its an absoulte path, no changes needed.
+                new URL(url);
+              } catch (error) {
+                // if the url doesn't have the protocol like //api.example.com
+                if (url.startsWith('//')) {
+                  url = `${baseURLObject.protocol}:${url}`;
+                } else {
+                  // if the url is a path name like / OR /v1/reports
+                  url = url === '/' ? baseURL : baseURL + url;
+                }
+              }
+              req.spec.servers[index].url = url;
+            });
+          }
+        }
         client = await SwaggerClient(req);
         if (debug.enabled) {
           debug('swagger loaded: %s', self.spec);

--- a/test/test-connector-openapi3.js
+++ b/test/test-connector-openapi3.js
@@ -12,6 +12,7 @@ const pEvent = require('p-event');
 
 describe('swagger connector for OpenApi 3.0', () => {
   let lb4App;
+  const specUrlWithoutServersField = 'https://restcountries.com/openapi/rest-countries-3.1.yml';
   let specUrl = 'http://127.0.0.1:3000/openapi.json';
 
   before(startLB4App);
@@ -33,6 +34,13 @@ describe('swagger connector for OpenApi 3.0', () => {
   });
 
   describe('openapi client generation', () => {
+    it('generates client from openapi spec url when specs doesnot have servers field', async () => {
+      const ds = await createDataSource(specUrlWithoutServersField);
+      ds.connector.should.have.property('client');
+      ds.connector.client.should.have.property('apis');
+      ds.connector.api.should.have.property('servers');
+    });
+
     it('generates client from openapi spec url', async () => {
       const ds = await createDataSource(specUrl);
       ds.connector.should.have.property('client');


### PR DESCRIPTION
In case the servers field is empty or doesn't contain an absolute URL, this PR makes the connector generate it from the specification URL.

Fixes #[9363](https://github.com/loopbackio/loopback-next/issues/9363)

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
